### PR TITLE
Allow disabling of disarm command

### DIFF
--- a/pima_server.py
+++ b/pima_server.py
@@ -139,6 +139,8 @@ def RunJsonCommand(query: dict) -> dict:
       mode = query['mode']
       if isinstance(mode, list):
         mode = mode[0]
+      if _parsed_args.disable_disarm and mode == 'disarm':
+        return {'error' : 'Disarm is disabled'}
       mode = pima.Arm[mode.upper()]
     except KeyError:
       return {'error': 'Invalid arm mode.'}
@@ -263,6 +265,8 @@ def ParseArguments() -> argparse.Namespace:
                           help='<user:password> for the MQTT channel.')
   arg_parser.add_argument('--mqtt_topic', default='pima_alarm',
                           help='MQTT topic.')
+  arg_parser.add_argument('--disable_disarm', action='store_true',
+                          help='Prevent disarming (arm only mode).')
   arg_parser.add_argument('--log_level', default='WARNING',
                           choices={'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'},
                           help='Minimal log level.')


### PR DESCRIPTION
Hi.
I Added a small change that allows the disabling of the disarm command.
I have the alarm code running on a more tightly secure host than my home assistant and I only wish to know the status of the system and lock it in case and I forgot to do so, not disarm it when I am not at home.