### PR TITLE
Retry to connect to MQTT broker on OSError

### DIFF
--- a/pima_server.py
+++ b/pima_server.py
@@ -316,7 +316,7 @@ if __name__ == '__main__':
     while True:
       try:
         _mqtt_client.connect(_parsed_args.mqtt_host, _parsed_args.mqtt_port)
-      except socket.timeout:
+      except (socket.timeout, OSError):
         logging.exception('Failed to connect to MQTT broker. Retrying in 5 seconds...')
         time.sleep(5)
       else:


### PR DESCRIPTION
After a power outage, when the network router is not yet up and running, connecting to the MQTT broker may fail with timeouts combined with OSError exceptions.
In such cases I have seen the following errors in the log:
`OSError: [Errno 113] No route to host`
In such a case, we need to retry connecting to MQTT, just like we do for a timeout.
Fixes deiger/Alarm#3