### PR TITLE
Separating the LWT state from the alarm state

### DIFF
--- a/hass/alarm.yaml
+++ b/hass/alarm.yaml
@@ -1,9 +1,9 @@
 # Pima Alarm
 alarm_control_panel:
-  - platform: manual
   - platform: mqtt
     state_topic: "pima_alarm/status"
     command_topic: "pima_alarm/command"
+    availability_topic: "pima_alarm/LWT"
     code_arm_required: false
     code_disarm_required: false
     value_template: >-

--- a/hass/alarm_sensors.yaml
+++ b/hass/alarm_sensors.yaml
@@ -3,12 +3,15 @@ sensor:
   - name: "Alarm Open Zones"
     platform: mqtt
     state_topic: "pima_alarm/status"
+    availability_topic: "pima_alarm/LWT"
     value_template: "{{ value_json['open zones'] }}"
   - name: "Alarm Alarmed Zones"
     platform: mqtt
     state_topic: "pima_alarm/status"
+    availability_topic: "pima_alarm/LWT"
     value_template: "{{ value_json['alarmed zones'] }}"
   - name: "Alarm Arm State"
     platform: mqtt
     state_topic: "pima_alarm/status"
+    availability_topic: "pima_alarm/LWT"
     value_template: "{{ value_json['partitions']['1'] }}"


### PR DESCRIPTION
Separating the LWT state from the alarm state is needed to allow simple integration with home-assistant, as HA requires a constant string for representing "online" availability.

Separating the LWT to a separate topic also allows making the LWT messages Retained.  This approach is consistent with the Tasmota devices' behavior.  More specifically, it allows the alarm to announce its Online state when it starts, and even when HA is restarted after the alarm announced that it is online, it would still know about the correct state.  An alternative approach can be to notify about the "online" state periodically.