### PR TITLE
Retain status message

### DIFF
--- a/pima_server.py
+++ b/pima_server.py
@@ -255,7 +255,7 @@ def mqtt_on_disconnect(client: mqtt.Client, userdata, rc):
 
 def mqtt_publish_status(status: dict) -> None:
   if _mqtt_client:
-    _mqtt_client.publish(_mqtt_topics['pub'], payload=to_json(status))
+    _mqtt_client.publish(_mqtt_topics['pub'], payload=to_json(status), retain=True)
 
 
 def mqtt_publish_discovery() -> None:


### PR DESCRIPTION
Fixes alarm_control_panel.pima_alarm `unavailable` state when HA core is restarted and MQTT is used.

Scenario:
1. Configure HA/MQTT. alarm_control_panel.pima_alarm state is armed/disarmed (correct)
2. Restart HA core - alarm_control_panel.pima_alarm will be `unavailable` until the next status is posted to MQTT

By enabling retention of the status, we make sure the previously posted status is pushed to HA core when it connects to MQTT - allowing it to immediately see the correct status.