### PR TITLE
Bumping paho-mqtt to v1.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name='pima',
-    version='0.7.2.7',
+    version='0.7.2.6',
     description='Interface for negotiation with PIMA Hunter Pro alarms.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name='pima',
-    version='0.7.2.6',
+    version='0.7.2.7',
     description='Interface for negotiation with PIMA Hunter Pro alarms.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -17,7 +17,7 @@ setuptools.setup(
     author_email='droreiger@gmail.com',
     license='GPL 3.0',
     packages=setuptools.find_packages(),
-    install_requires=['crcmod', 'paho-mqtt==1.5.0', 'pyserial'],
+    install_requires=['crcmod', 'paho-mqtt==1.6.1', 'pyserial'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
Resolve the issue of breaking service after mqtt disarm/arm by upgrading paho-mqtt library to version 1.6.1.
Fixed #16 .