### PR TITLE
Exit on `Not enough data`, `Garbage` and etc to prevent freezes

### DIFF
--- a/pima.py
+++ b/pima.py
@@ -290,17 +290,21 @@ class Alarm(object):
     data = bytes([length]) + self._channel.read(length + 2)
     if data == bytes([length]) * len(data):
       raise GarbageInputError('Garbage ({})!'.format(length))
+      sys.exit(1)
     if len(data) != length + 3:
       raise Error('Not enough data in channel: {} should have {} bytes.'.format(
           self._make_hex(data), length + 3))
+      sys.exit(1)
     logging.debug('>>> ' + self._make_hex(data))
     data, crc = data[:-2], int.from_bytes(data[-2:], byteorder='big')
     if (crc != self._crc(data)):
       raise Error('Invalid input on channel, CRC for {} is {}, not {}!'.format(
           self._make_hex(data), self._crc(data), crc))
+      sys.exit(1)
     if self._module_id != data[1:2]:
       raise Error('Invalid module ID. Expected {}, got {}'.format(self._make_hex(self._module_id),
                                                                   self._make_hex(data[1:2])))
+      sys.exit(1)
     return data
 
   def _send_message(self,

--- a/pima.py
+++ b/pima.py
@@ -289,20 +289,20 @@ class Alarm(object):
     length = ord(data)
     data = bytes([length]) + self._channel.read(length + 2)
     if data == bytes([length]) * len(data):
-      raise GarbageInputError('Garbage ({})!'.format(length))
+      print('Garbage ({})!'.format(length))
       sys.exit(1)
     if len(data) != length + 3:
-      raise Error('Not enough data in channel: {} should have {} bytes.'.format(
+      print('Not enough data in channel: {} should have {} bytes.'.format(
           self._make_hex(data), length + 3))
       sys.exit(1)
     logging.debug('>>> ' + self._make_hex(data))
     data, crc = data[:-2], int.from_bytes(data[-2:], byteorder='big')
     if (crc != self._crc(data)):
-      raise Error('Invalid input on channel, CRC for {} is {}, not {}!'.format(
+      print('Invalid input on channel, CRC for {} is {}, not {}!'.format(
           self._make_hex(data), self._crc(data), crc))
       sys.exit(1)
     if self._module_id != data[1:2]:
-      raise Error('Invalid module ID. Expected {}, got {}'.format(self._make_hex(self._module_id),
+      print('Invalid module ID. Expected {}, got {}'.format(self._make_hex(self._module_id),
                                                                   self._make_hex(data[1:2])))
       sys.exit(1)
     return data


### PR DESCRIPTION
I installed this project as an Home Assistant addon and noticed that every about 30-60 minutes, it would just freeze with a `not enough data...` error and never exit, resulting in HA's watchdog not detecting it as a crash & not restarting the addon.

This PR should resolve this issue completely by exiting when these errors occur, prompting watchdog to restart the addon.

(This should also resolve issue #9)