### PR TITLE
Set MQTT discovery entity name to None to solve #25

### DIFF
--- a/pima_server.py
+++ b/pima_server.py
@@ -283,7 +283,7 @@ def mqtt_publish_discovery() -> None:
     }
     alarm_config = {
         'name':
-            'PIMA Alarm',
+            None,
         'unique_id':
             'pima_alarm',
         'device':


### PR DESCRIPTION
To avoid the following warning in the home assistant core logs:

> MQTT device name is equal to entity name in your config {...} this is not expected. Please correct your configuration. The entity name will be set to null.

The device and the main entity should not have the same name "PIMA Alarm".

According to the current HA documentation, the main entity of a device should have a null value for the name. This will automatically name the entity with the same name. This is the same result as we had before, just without the annoying warning in the log.

See official documentation: https://www.home-assistant.io/integrations/mqtt/