### PR TITLE
Fixed Home Assistant 2026.9 support

### DIFF
--- a/pima_server.py
+++ b/pima_server.py
@@ -345,7 +345,7 @@ def mqtt_publish_discovery() -> None:
           'unique_id':
               f'pima_alarm_zone_{i}_open',
           'device': {
-              **device_info, 'via_device': 'pima_alarm'
+              **device_info,
           },
           'state_topic':
               _mqtt_topics['pub'],
@@ -364,7 +364,7 @@ def mqtt_publish_discovery() -> None:
           'unique_id':
               f'pima_alarm_zone_{i}_alarming',
           'device': {
-              **device_info, 'via_device': 'pima_alarm'
+              **device_info,
           },
           'state_topic':
               _mqtt_topics['pub'],

--- a/pima_server.py
+++ b/pima_server.py
@@ -335,41 +335,47 @@ def mqtt_publish_discovery() -> None:
         'payload_arm_away':
             '{"command": "arm", "mode": "full_arm"}'
     }
-    _mqtt_client.publish(_mqtt_topics['discovery'].format('alarm_control_panel'),
+    _mqtt_client.publish(_mqtt_topics['discovery'].format('alarm_control_panel/pima_alarm'),
                          payload=to_json(alarm_config),
                          retain=True)
     for i in range(1, min(_parsed_args.mqtt_discovery_max_zone, _parsed_args.zones) + 1):
+      old_open_topic = os.path.join(_parsed_args.mqtt_discovery_prefix,
+                                    'binary_sensor', f'open_zone_{i}', 'pima_alarm', 'config')
+      old_alarmed_topic = os.path.join(_parsed_args.mqtt_discovery_prefix,
+                                       'binary_sensor', f'alarmed_zone_{i}', 'pima_alarm',
+                                       'config')
+      _mqtt_client.publish(old_open_topic, payload='', retain=True)
+      _mqtt_client.publish(old_alarmed_topic, payload='', retain=True)
       open_zones_config = {
           'name':
               f'Alarm Zone {i} Open',
           'unique_id':
               f'pima_alarm_zone_{i}_open',
-          'device': {
-              **device_info,
-          },
+          'device':
+            device_info,
           'state_topic':
               _mqtt_topics['pub'],
           'availability_topic':
-              _mqtt_topics['lwt'],
+            _mqtt_topics['lwt'],
           'payload_on':
               'on',
           'payload_off':
               'off',
           'value_template':
-              f"{{% if {i} in value_json['open zones'] %}}on{{% else %}}off{{% endif %}}"
+              f"{{% if {i} in value_json['open zones'] %}}on{{% else %}}off{{% endif %}}",
+          'device_class': 'motion'
       }
       alarmed_zones_config = {
           'name':
               f'Alarm Zone {i} Alarming',
           'unique_id':
               f'pima_alarm_zone_{i}_alarming',
-          'device': {
-              **device_info,
-          },
+          'device':
+            device_info,
           'state_topic':
               _mqtt_topics['pub'],
           'availability_topic':
-              _mqtt_topics['lwt'],
+            _mqtt_topics['lwt'],
           'payload_on':
               'on',
           'payload_off':
@@ -377,12 +383,14 @@ def mqtt_publish_discovery() -> None:
           'value_template':
               f"{{% if {i} in value_json['alarmed zones'] %}}on{{% else %}}off{{% endif %}}"
       }
-      _mqtt_client.publish(_mqtt_topics['discovery'].format(f'binary_sensor/open_zone_{i}'),
-                           payload=to_json(open_zones_config),
-                           retain=True)
-      _mqtt_client.publish(_mqtt_topics['discovery'].format(f'binary_sensor/alarmed_zone_{i}'),
-                           payload=to_json(alarmed_zones_config),
-                           retain=True)
+      _mqtt_client.publish(
+          _mqtt_topics['discovery'].format(f'binary_sensor/pima_alarm_zone_{i}_open'),
+          payload=to_json(open_zones_config),
+          retain=True)
+      _mqtt_client.publish(
+          _mqtt_topics['discovery'].format(f'binary_sensor/pima_alarm_zone_{i}_alarming'),
+          payload=to_json(alarmed_zones_config),
+          retain=True)
 
 
 def mqtt_publish_lwt_online() -> None:

--- a/pima_server.py
+++ b/pima_server.py
@@ -383,7 +383,6 @@ def mqtt_publish_discovery() -> None:
           'value_template':
               f"{{% if {i} in value_json['alarmed zones'] %}}on{{% else %}}off{{% endif %}}"
       }
-
       _mqtt_client.publish(
           _mqtt_topics['discovery'].format(f'binary_sensor/pima_alarm_zone_{i}_open'),
           payload=to_json(open_zones_config),

--- a/pima_server.py
+++ b/pima_server.py
@@ -397,9 +397,8 @@ def mqtt_publish_discovery() -> None:
         'PIMA Status',
       'unique_id':
         'pima_alarm_status',
-      'device': {
-        **device_info,
-      },
+      'device':
+        device_info,
       'state_topic':
         _mqtt_topics['lwt'],
       'device_class':

--- a/pima_server.py
+++ b/pima_server.py
@@ -375,7 +375,7 @@ def mqtt_publish_discovery() -> None:
           'state_topic':
               _mqtt_topics['pub'],
           'availability_topic':
-            _mqtt_topics['lwt'],
+              _mqtt_topics['lwt'],
           'payload_on':
               'on',
           'payload_off':

--- a/pima_server.py
+++ b/pima_server.py
@@ -352,7 +352,7 @@ def mqtt_publish_discovery() -> None:
           'unique_id':
               f'pima_alarm_zone_{i}_open',
           'device':
-            device_info,
+              device_info,
           'state_topic':
               _mqtt_topics['pub'],
           'availability_topic':

--- a/pima_server.py
+++ b/pima_server.py
@@ -356,7 +356,7 @@ def mqtt_publish_discovery() -> None:
           'state_topic':
               _mqtt_topics['pub'],
           'availability_topic':
-            _mqtt_topics['lwt'],
+              _mqtt_topics['lwt'],
           'payload_on':
               'on',
           'payload_off':


### PR DESCRIPTION
Home Assistant 2026.9 introduced stricter MQTT checks, so setting `via_device` will just trigger this error:

```py
Logger: homeassistant.components.binary_sensor
Source: helpers/entity_platform.py:725
Integration: Binary sensor (documentation, issues)
First occurred: 2:18:51 AM (14 occurrences)
Last logged: 2:18:51 AM

Error adding entity None for domain binary_sensor with platform mqtt
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 725, in _async_add_entities
    await self._async_add_entity(
        entity, False, entity_registry, config_subentry_id
    )
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 971, in _async_add_entity
    device = dev_reg.async_get_or_create(
        config_entry_id=self.config_entry.entry_id,
    ...<8 lines>...
        ),
    )
  File "/usr/src/homeassistant/homeassistant/helpers/device_registry.py", line 2562, in async_get_or_create
    device = self._async_update_device(
        device.id,
    ...<9 lines>...
        **validated_fields,
    )
  File "/usr/src/homeassistant/homeassistant/helpers/device_registry.py", line 3083, in _async_update_device
    raise HomeAssistantError("A device can not be its own via device")
homeassistant.exceptions.HomeAssistantError: A device can not be its own via device
```

Which will also make all sensors unavailable